### PR TITLE
add support for piping commands

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func cd(args []string) {
+	var path string
+	if len(args) > 0 {
+		path = args[0]
+	} else {
+		path, _ = os.UserHomeDir()
+	}
+
+	var err = os.Chdir(path)
+	if err != nil {
+		fmt.Println(strings.Replace(err.Error(), "chdir", "cd", -1))
+	}
+}
+
+func pwd(writer *io.PipeWriter) {
+	defer func(writer *io.PipeWriter) {
+		err := writer.Close()
+		if err != nil {
+			fmt.Println(err)
+		}
+	}(writer)
+
+	dir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	_, err = fmt.Fprintln(writer, dir)
+	if err != nil {
+		fmt.Println(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,37 +15,70 @@ func main() {
 
 		reader := bufio.NewReader(os.Stdin)
 		input, _ := reader.ReadString('\n')
-		input = strings.TrimSpace(input)
+		commands := strings.Split(input, "|")
 
-		parts := strings.Fields(input)
-		var command = parts[0]
-		var args = parts[1:]
+		var cmds []*exec.Cmd
+		var output io.ReadCloser
 
-		switch command {
-		case "":
-			continue
-		case "exit":
-			os.Exit(0)
-		case "cd":
-			var path string
-			if len(args) > 0 {
-				path = args[0]
-			} else {
-				path, _ = os.UserHomeDir()
+		for _, command := range commands {
+			command = strings.TrimSpace(command)
+			parts := strings.Fields(command)
+			var command = parts[0]
+			var args = parts[1:]
+
+			switch command {
+			case "":
+				continue
+			case "exit":
+				os.Exit(0)
+			case "cd":
+				cd(args)
+			case "pwd":
+				pipeReader, pipeWriter := io.Pipe()
+				go pwd(pipeWriter)
+				if len(commands) == 1 {
+					_, err := io.Copy(os.Stdout, pipeReader)
+					if err != nil {
+						fmt.Println(err)
+						return
+					}
+				} else {
+					output = pipeReader
+				}
+			default:
+				cmd := exec.Command(command, args...)
+				cmd.Stderr = os.Stderr
+
+				cmds = append(cmds, cmd)
+
+				if output != nil {
+					cmd.Stdin = output
+				}
+				var err error
+				output, err = cmd.StdoutPipe()
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
 			}
+		}
+		if len(cmds) > 0 {
+			cmds[len(cmds)-1].Stdout = os.Stdout
+		}
 
-			var err = os.Chdir(path)
-			if err != nil {
-				fmt.Println(strings.Replace(err.Error(), "chdir", "cd", -1))
-			}
-		default:
-			cmd := exec.Command(command, args...)
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-
-			err := cmd.Run()
+		for _, cmd := range cmds {
+			err := cmd.Start()
 			if err != nil {
 				fmt.Println(err)
+				return
+			}
+		}
+
+		for _, cmd := range cmds {
+			err := cmd.Wait()
+			if err != nil {
+				fmt.Println(err)
+				return
 			}
 		}
 	}


### PR DESCRIPTION
Adds support for users to "pipe" commands together using the '|' character.

"Piping" refers to running multiple commands in sequence, using the output from each command as the input of the next.