### PR TITLE
ignore interrupting signals

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,15 +6,22 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 )
 
 func main() {
+	signal.Ignore(os.Interrupt)
+
 	for {
 		fmt.Print("gosh> ")
 
 		reader := bufio.NewReader(os.Stdin)
 		input, _ := reader.ReadString('\n')
+		input = strings.TrimSpace(input)
+		if input == "" {
+			continue
+		}
 		commands := strings.Split(input, "|")
 
 		var cmds []*exec.Cmd


### PR DESCRIPTION
Interruption signals should only exit programs run but gosh but not the shell itself, so we need to ignore them at the shell level.